### PR TITLE
args adapting

### DIFF
--- a/core/src/main/java/io/roastedroot/quickjs4j/core/Engine.java
+++ b/core/src/main/java/io/roastedroot/quickjs4j/core/Engine.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @WasmModuleInterface(WasmResource.absoluteFile)
 public final class Engine implements AutoCloseable {
@@ -233,22 +232,12 @@ public final class Engine implements AutoCloseable {
         try {
             JsonNode tree = mapper.readTree(argsString);
 
-            if (tree.size() != receiver.paramTypes().size()) {
-                throw new IllegalArgumentException(
-                        "Function "
-                                + receiver.name()
-                                + " has been invoked with the incorrect number of parameters"
-                                + " needs: "
-                                + receiver.paramTypes().stream()
-                                        .map(Class::getCanonicalName)
-                                        .collect(Collectors.joining(", "))
-                                + ", found: "
-                                + tree.size());
-            }
-
-            for (int i = 0; i < tree.size(); i++) {
+            for (int i = 0; i < receiver.paramTypes().size(); i++) {
                 var clazz = receiver.paramTypes().get(i);
-                var value = tree.get(i);
+                JsonNode value = null;
+                if (tree.size() > i) {
+                    value = tree.get(i);
+                }
 
                 if (clazz == HostRef.class) {
                     argsList.add(javaRefs.get(value.intValue()));

--- a/core/src/test/java/io/roastedroot/quickjs4j/core/RunnerTest.java
+++ b/core/src/test/java/io/roastedroot/quickjs4j/core/RunnerTest.java
@@ -39,6 +39,68 @@ public class RunnerTest {
     }
 
     @Test
+    public void expandArgsWithNulls() {
+        // Arrange
+        var invoked = new AtomicBoolean(false);
+        var builtins =
+                Builtins.builder("from_java")
+                        .add(
+                                new HostFunction(
+                                        "java_check",
+                                        List.of(Integer.class, Integer.class),
+                                        Integer.class,
+                                        (args) -> {
+                                            invoked.set(true);
+                                            assertEquals(1, args.get(0));
+                                            assertEquals(null, args.get(1));
+                                            assertEquals(2, args.size());
+                                            return 1;
+                                        }))
+                        .build();
+        var jsEngine = Engine.builder().addBuiltins(builtins).build();
+        var runner = Runner.builder().withEngine(jsEngine).build();
+
+        // Act
+        runner.compileAndExec("from_java.java_check(1);");
+
+        // Assert
+        assertTrue(invoked.get());
+
+        runner.close();
+    }
+
+    @Test
+    public void adaptArgsWithNulls() {
+        // Arrange
+        var invoked = new AtomicBoolean(false);
+        var builtins =
+                Builtins.builder("from_java")
+                        .add(
+                                new HostFunction(
+                                        "java_check",
+                                        List.of(Integer.class, Integer.class),
+                                        Integer.class,
+                                        (args) -> {
+                                            invoked.set(true);
+                                            assertEquals(1, args.get(0));
+                                            assertEquals(2, args.get(1));
+                                            assertEquals(2, args.size());
+                                            return 1;
+                                        }))
+                        .build();
+        var jsEngine = Engine.builder().addBuiltins(builtins).build();
+        var runner = Runner.builder().withEngine(jsEngine).build();
+
+        // Act
+        runner.compileAndExec("from_java.java_check(1, 2, 3);");
+
+        // Assert
+        assertTrue(invoked.get());
+
+        runner.close();
+    }
+
+    @Test
     public void fullUsage() {
         // Arrange
         var invoked = new AtomicBoolean(false);


### PR DESCRIPTION
As observed here: https://github.com/microcks/microcks/pull/1656#discussion_r2219633472
It's not possible to do methods overloading in JS based on the number of arguments passed to the function.

This makes it impractical to fix the number of expected arguments, resulting in verbode JS APIs, and we give much more freedom to the implementer by adapting them to the correct size as JS does.