### PR TITLE
Improve Chicory DX

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,11 +16,6 @@
   <dependencies>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
-      <artifactId>annotations</artifactId>
-      <version>${chicory.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.dylibso.chicory</groupId>
       <artifactId>runtime</artifactId>
       <version>${chicory.version}</version>
     </dependency>
@@ -73,6 +68,7 @@
             <configuration>
               <name>io.roastedroot.quickjs4j.core.JavyPluginModule</name>
               <wasmFile>../javy_quickjs4j_plugin.wasm</wasmFile>
+              <moduleInterface>io.roastedroot.quickjs4j.core.Engine</moduleInterface>
             </configuration>
           </execution>
         </executions>
@@ -93,19 +89,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>com.dylibso.chicory</groupId>
-              <artifactId>annotations-processor</artifactId>
-              <version>${chicory.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>templating-maven-plugin</artifactId>
         <executions>
@@ -117,6 +100,7 @@
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 </project>

--- a/core/src/main/java-templates/io/roastedroot/quickjs4j/core/WasmResource.java
+++ b/core/src/main/java-templates/io/roastedroot/quickjs4j/core/WasmResource.java
@@ -1,7 +1,0 @@
-package io.roastedroot.quickjs4j.core;
-
-public final class WasmResource {
-    public static final String absoluteFile = "file://${project.basedir}/../javy_quickjs4j_plugin.wasm";
-
-    private WasmResource() {}
-}

--- a/core/src/main/java/io/roastedroot/quickjs4j/core/Engine.java
+++ b/core/src/main/java/io/roastedroot/quickjs4j/core/Engine.java
@@ -2,7 +2,6 @@ package io.roastedroot.quickjs4j.core;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.dylibso.chicory.annotations.WasmModuleInterface;
 import com.dylibso.chicory.log.Logger;
 import com.dylibso.chicory.log.SystemLogger;
 import com.dylibso.chicory.runtime.ByteArrayMemory;
@@ -26,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-@WasmModuleInterface(WasmResource.absoluteFile)
 public final class Engine implements AutoCloseable {
     private static final int ALIGNMENT = 1;
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,6 @@
           <configuration>
             <parameters>true</parameters>
             <release>11</release>
-            <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
           </configuration>
         </plugin>
         <plugin>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -42,7 +42,6 @@
         <configuration>
           <parameters>true</parameters>
           <release>11</release>
-          <annotationProcessorPathsUseDepMgmt>true</annotationProcessorPathsUseDepMgmt>
           <compilerArgs>-proc:none</compilerArgs>
         </configuration>
       </plugin>


### PR DESCRIPTION
Use chicory-compiler-maven-plugin moduleInterface instead of annotation processor

Replace the @WasmModuleInterface annotation-based approach with the new moduleInterface config on the chicory-compiler-maven-plugin, removing the need for the chicory annotations dependency, annotation processor, and WasmResource template.